### PR TITLE
Add lint-test workflow

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -1,0 +1,73 @@
+name: Lint and Test Charts
+
+on: pull_request
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.8.1
+
+      # Python is required because `ct lint` runs Yamale (https://github.com/23andMe/Yamale) and
+      # yamllint (https://github.com/adrienverge/yamllint) which require Python
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.2.1
+        with:
+          version: v3.7.1
+
+      - name: Run chart-testing (lint)
+        run: ct lint --config ct.yaml --chart-dirs . --charts .
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.5.0
+
+      # --skip-clean-up isn't currently released
+      #- name: Run chart-testing (install)
+      #  id: install
+      #  run: ct install --config ct.yaml --chart-dirs . --charts . --skip-clean-up
+
+      # Manually doing install and wait since chart-testing is removing the cluster
+      - name: install chart
+        id: install
+        run: helm install -n default ci . -f values.yaml
+
+      - name: wait for pods
+        run: kubectl wait --for=condition=ready -n default po --all --timeout=60s
+
+      - name: wait for pvc
+        run: kubectl wait --for=jsonpath='{.status.phase}'=Bound -A pvc --all --timeout=10s
+
+      - name: wait for pv
+        run: kubectl wait --for=jsonpath='{.status.phase}'=Bound -A pv --all --timeout=10s
+
+      - name: test chart
+        id: test
+        run: helm test ci
+
+      - name: install troubleshoot
+        run: curl -L https://github.com/replicatedhq/troubleshoot/releases/latest/download/support-bundle_linux_amd64.tar.gz | tar xzvf -
+        if: success() || failure()
+
+      - name: collect bundle
+        run: ./support-bundle --interactive=false -o ci-bundle https://raw.githubusercontent.com/replicatedhq/troubleshoot-specs/main/host/cluster-down.yaml https://raw.githubusercontent.com/replicatedhq/troubleshoot-specs/main/in-cluster/default.yaml 
+        if: success() || failure()
+
+      - name: Upload support bundle artifact
+        uses: actions/upload-artifact@v3
+        if: success() || failure()
+        with:
+          name: support-bundle
+          path: 'ci-bundle.tar.gz'

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+charts/

--- a/Chart.lock
+++ b/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: replicated-library
+  repository: https://replicatedhq.github.io/helm-charts
+  version: 0.1.1
+digest: sha256:bd3c725daca5b08fc5b8e4247f7c792eee3055cf3a527d5ff369f662f08e3787
+generated: "2023-03-22T15:37:53.375057-05:00"

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,0 +1,10 @@
+# See https://github.com/helm/chart-testing#configuration
+remote: origin
+target-branch: "replicated-library-chart"
+chart-repos:
+  - replicated=https://replicatedhq.github.io/helm-charts
+chart-dirs:
+  - "."
+charts:
+  - "."
+validate-maintainers: false

--- a/values.yaml
+++ b/values.yaml
@@ -8,7 +8,7 @@ apps:
     type: deployment
     replicas: 1
     containers:
-      vaultwarden: 
+      vaultwarden:
         image:
           repository: vaultwarden/server
           tag: 1.27.0-alpine
@@ -47,7 +47,6 @@ persistence:
     type: persistentVolumeClaim
     persistentVolumeClaim:
       spec:
-        storageClassName: default
         accessModes:
           - ReadWriteOnce
         resources:


### PR DESCRIPTION
Adding a workflow to lint the chart and verify it deploys. This doesn't add any actual tests to the helm deploy so it's only currently verifying that the install command doesn't error, but tests can be added as a follow on.