### PR TITLE
Vaultwarden Native Helm v2

### DIFF
--- a/manifests/kots-helm.yaml
+++ b/manifests/kots-helm.yaml
@@ -1,4 +1,4 @@
-apiVersion: kots.io/v1beta1
+apiVersion: kots.io/v1beta2
 kind: HelmChart
 metadata:
   name: vaultwarden


### PR DESCRIPTION
* Using `kots.io/v1beta2` for Vaultwarden