### PR TITLE
Update .helmignore

### DIFF
--- a/.helmignore
+++ b/.helmignore
@@ -23,5 +23,6 @@
 .vscode/
 manifests/
 doc/
+examples/
 kurl-installer.yaml
 ct.yaml


### PR DESCRIPTION
Adds the folder `examples` to the Helm ignore to make building better.